### PR TITLE
Fix getting number of failures and total requests for asyncio CB

### DIFF
--- a/lasier/circuit_breaker/asyncio.py
+++ b/lasier/circuit_breaker/asyncio.py
@@ -9,10 +9,10 @@ class CircuitBreaker(CircuitBreakerBase):
     async def is_circuit_open(self):
         return await self.cache.get(self.circuit_cache_key) or False
 
-    async def total_failures(self):
+    async def get_total_failures(self):
         return await self.cache.get(self.rule.failure_cache_key) or 0
 
-    async def total_requests(self):
+    async def get_total_requests(self):
         return await self.cache.get(self.rule.request_cache_key) or 0
 
     async def open_circuit(self):
@@ -43,8 +43,8 @@ class CircuitBreaker(CircuitBreakerBase):
         if self._is_catchable_exception(exc_type):
             await self._increase_failure_count()
 
-            total_failures = await self.total_failures()
-            total_requests = await self.total_requests()
+            total_failures = await self.get_total_failures()
+            total_requests = await self.get_total_requests()
 
             if self.rule.should_open_circuit(
                 total_failures=total_failures,
@@ -77,7 +77,7 @@ class CircuitBreaker(CircuitBreakerBase):
         )
 
         total_failures = await self.cache.incr(self.rule.failure_cache_key)
-        total_requests = await self.total_requests()
+        total_requests = await self.get_total_requests()
 
         self.rule.log_increase_failures(
             total_failures=total_failures,

--- a/lasier/circuit_breaker/sync.py
+++ b/lasier/circuit_breaker/sync.py
@@ -15,10 +15,10 @@ class CircuitBreaker(CircuitBreakerBase):
     def is_circuit_open(self):
         return self.cache.get(self.circuit_cache_key) == 1
 
-    def total_failures(self):
+    def get_total_failures(self):
         return self.cache.get(self.rule.failure_cache_key) or 0
 
-    def total_requests(self):
+    def get_total_requests(self):
         return self.cache.get(self.rule.request_cache_key) or 0
 
     def open_circuit(self):
@@ -44,8 +44,8 @@ class CircuitBreaker(CircuitBreakerBase):
             self._increase_failure_count()
 
             if self.rule.should_open_circuit(
-                total_failures=self.total_failures(),
-                total_requests=self.total_requests()
+                total_failures=self.get_total_failures(),
+                total_requests=self.get_total_requests()
             ):
                 self.open_circuit()
                 self._notify_max_failures_exceeded()
@@ -68,11 +68,11 @@ class CircuitBreaker(CircuitBreakerBase):
         # Between the cache.add and cache.incr, the cache MAY expire,
         # which will lead to a circuit that will eventually open
         self.cache.add(self.rule.failure_cache_key, 0, self.failure_timeout)
-        total = self.cache.incr(self.rule.failure_cache_key)
+        total_failures = self.cache.incr(self.rule.failure_cache_key)
 
         self.rule.log_increase_failures(
-            total_failures=total,
-            total_requests=self.total_requests()
+            total_failures=total_failures,
+            total_requests=self.get_total_requests()
         )
 
     def _increase_request_count(self):


### PR DESCRIPTION
This PR intend to fix the error below:

```
    def _get_percentage_failures(self, total_failures, total_requests):
>       if total_requests > 0:
E       TypeError: '>' not supported between instances of 'method' and 'int'
```
This happens when CB is evaluated if it should be opened. The method expected a number a was getting a coroutine instead.