### PR TITLE
Ignore request cache key when is not set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [NEXT_RELEASE]
+
+### Changes
+
+* Ignore request cache key operations when it is not configured
+
 ## [0.1.0] - 2020-05-15
 ### Changes
 * Args `failure_timeout` and `circuit_timeout` of CircuitBreaker to have a default value

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ check:  ## Run static code checks
 test: clean  ## Run unit tests
 	@py.test -x tests/
 
+test-matching:
+	@py.test -rxs --pdb -k$(Q) tests/
+
 coverage:  ## Run unit tests and generate code coverage report
 	@py.test -x --cov lasier/ --cov-report=xml --cov-report=term-missing tests/
 

--- a/lasier/circuit_breaker/asyncio.py
+++ b/lasier/circuit_breaker/asyncio.py
@@ -26,8 +26,7 @@ class CircuitBreaker(CircuitBreakerBase):
         # when a key is created accidentally without timeout (from an incr
         # operation)
 
-        if self.rule.should_increase_request_count():
-
+        if self.rule.request_cache_key is not None:
             await asyncio.gather(
                 self.cache.delete(self.rule.failure_cache_key),
                 self.cache.delete(self.rule.request_cache_key),

--- a/lasier/circuit_breaker/sync.py
+++ b/lasier/circuit_breaker/sync.py
@@ -19,6 +19,9 @@ class CircuitBreaker(CircuitBreakerBase):
         return self.cache.get(self.rule.failure_cache_key) or 0
 
     def get_total_requests(self) -> int:
+        if not self.rule.should_increase_request_count():
+            return 0
+
         return self.cache.get(self.rule.request_cache_key) or 0
 
     def open_circuit(self) -> None:
@@ -28,7 +31,9 @@ class CircuitBreaker(CircuitBreakerBase):
         # when a key is created accidentally without timeout (from an incr
         # operation)
         self.cache.delete(self.rule.failure_cache_key)
-        self.cache.delete(self.rule.request_cache_key)
+
+        if self.rule.should_increase_request_count():
+            self.cache.delete(self.rule.request_cache_key)
 
         self._notify_open_circuit()
 

--- a/lasier/circuit_breaker/sync.py
+++ b/lasier/circuit_breaker/sync.py
@@ -19,7 +19,7 @@ class CircuitBreaker(CircuitBreakerBase):
         return self.cache.get(self.rule.failure_cache_key) or 0
 
     def get_total_requests(self) -> int:
-        if not self.rule.should_increase_request_count():
+        if self.rule.request_cache_key is None:
             return 0
 
         return self.cache.get(self.rule.request_cache_key) or 0
@@ -32,7 +32,7 @@ class CircuitBreaker(CircuitBreakerBase):
         # operation)
         self.cache.delete(self.rule.failure_cache_key)
 
-        if self.rule.should_increase_request_count():
+        if self.rule.request_cache_key is not None:
             self.cache.delete(self.rule.request_cache_key)
 
         self._notify_open_circuit()

--- a/tests/circuit_breaker/conftest.py
+++ b/tests/circuit_breaker/conftest.py
@@ -43,6 +43,13 @@ def should_open_rule(failure_cache_key, request_cache_key):
 
 
 @pytest.fixture
+def should_not_open_rule_without_request_cache_key(failure_cache_key):
+    return ShouldNotOpenRule(
+        failure_cache_key=failure_cache_key,
+    )
+
+
+@pytest.fixture
 def should_not_increase_request_rule(failure_cache_key, request_cache_key):
     return ShouldNotIncreaseRequestRule(
         failure_cache_key=failure_cache_key,

--- a/tests/circuit_breaker/test_async.py
+++ b/tests/circuit_breaker/test_async.py
@@ -323,6 +323,26 @@ class TestCircuitBreaker:
 
         assert await async_cache.get(failure_cache_key) == 0
 
+    async def test_should_create_failure_cache_when_no_request_cache_key(
+        self,
+        async_cache,
+        should_not_open_rule_without_request_cache_key,
+        failure_cache_key,
+        request_cache_key,
+    ):
+        assert await async_cache.get(failure_cache_key) is None
+
+        with pytest.raises(ValueError):
+            async with CircuitBreaker(
+                rule=should_not_open_rule_without_request_cache_key,
+                cache=async_cache,
+                failure_exception=MyException,
+                catch_exceptions=(ValueError,),
+            ):
+                await fail_function()
+
+        assert await async_cache.get(failure_cache_key) == 1
+
     async def test_should_call_expire_if_incr_returns_one(
         self,
         async_cache,

--- a/tests/circuit_breaker/test_sync.py
+++ b/tests/circuit_breaker/test_sync.py
@@ -309,6 +309,26 @@ class TestCircuitBreaker:
 
         assert cache.get(failure_cache_key) == 0
 
+    def test_should_create_failure_cache_when_no_request_cache_key(
+        self,
+        cache,
+        should_not_open_rule_without_request_cache_key,
+        failure_cache_key,
+        request_cache_key,
+    ):
+        assert cache.get(failure_cache_key) is None
+
+        with pytest.raises(ValueError):
+            with CircuitBreaker(
+                rule=should_not_open_rule_without_request_cache_key,
+                cache=cache,
+                failure_exception=MyException,
+                catch_exceptions=(ValueError,),
+            ):
+                fail_function()
+
+        assert cache.get(failure_cache_key) == 1
+
     def test_should_call_expire_if_incr_returns_one(
         self,
         cache,


### PR DESCRIPTION
Ignore operations regarding request cache key when it is not configured.

Why?

For Circuit Breaker rules like [MaxFailuresRule](https://github.com/luizalabs/lasier/blob/master/lasier/circuit_breaker/rules/max_failures.py#L9), the key is not set, which was causing some unexpected behaviors, since the key `request_cache_key` was `None` and some cache operations was being performed anyway without validations.

This PR intents to correct this behaviour, by only performing operations on cache when this key is set.