### PR TITLE
Adds async adapter for Django

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+.vscode
+.idea

--- a/README.md
+++ b/README.md
@@ -160,8 +160,9 @@ cache = RedisAdapter(Redis(host='localhost', port=6479, db=0))
 ```
 
 #### Implemented Adapters
-| Lib | Adapter |
-| --- | --- |
-| redis-py | `lasier.adapters.caches.RedisAdapter`|
-| django-cache | `lasier.adapters.caches.DjangoAdapter`|
-| aiocache | `lasier.adapters.caches.AiocacheAdapter`|
+| Lib                | Adapter                                       |
+|--------------------| --------------------------------------------- |
+| redis-py           | `lasier.adapters.caches.RedisAdapter`         |
+| django-cache       | `lasier.adapters.caches.DjangoAdapter`        |
+| django-cache-async | `lasier.adapters.caches.DjangoAsyncAdapter`   |
+| aiocache           | `lasier.adapters.caches.AiocacheAdapter`      |

--- a/lasier/adapters/caches/__init__.py
+++ b/lasier/adapters/caches/__init__.py
@@ -1,3 +1,4 @@
 from .aiocache import Adapter as AiocacheAdapter  # noqa
 from .django import Adapter as DjangoAdapter  # noqa
+from .django import AdapterAsync as DjangoAsyncAdapter  # noqa
 from .redis import Adapter as RedisAdapter  # noqa

--- a/lasier/adapters/caches/django.py
+++ b/lasier/adapters/caches/django.py
@@ -1,6 +1,8 @@
+from typing import Optional
+
 from lasier.types import Timeout
 
-from .base import CacheAdapterBase
+from .base import AsyncCacheAdapterBase, CacheAdapterBase
 
 
 class Adapter(CacheAdapterBase):
@@ -16,3 +18,30 @@ class Adapter(CacheAdapterBase):
 
     def flushdb(self) -> None:
         self.cache.clear()
+
+
+class AdapterAsync(AsyncCacheAdapterBase):
+    async def add(self, key: str, value: int, timeout: Timeout = None) -> None:
+        await self.cache.aadd(key, value, timeout)
+
+    async def set(self, key: str, value: int, timeout: Timeout = None) -> None:
+        await self.cache.aset(key, value, timeout)
+
+    async def incr(self, key: str) -> int:
+        try:
+            return await self.cache.aincr(key)
+        except ValueError:
+            await self.cache.aadd(key, 1)
+            return 1
+
+    async def get(self, key: str) -> Optional[int]:
+        return self._convert_to_int(await self.cache.aget(key))
+
+    async def expire(self, key: str, timeout: Timeout) -> None:
+        await self.cache.atouch(key, timeout)
+
+    async def delete(self, key: str) -> None:
+        await self.cache.adelete(key)
+
+    async def flushdb(self) -> None:
+        await self.cache.aclear()

--- a/tests/circuit_breaker/conftest.py
+++ b/tests/circuit_breaker/conftest.py
@@ -3,7 +3,12 @@ from aiocache import Cache
 from django.core.cache.backends.locmem import LocMemCache
 from fakeredis import FakeStrictRedis
 
-from lasier.adapters.caches import AiocacheAdapter, DjangoAdapter, RedisAdapter
+from lasier.adapters.caches import (
+    AiocacheAdapter,
+    DjangoAdapter,
+    DjangoAsyncAdapter,
+    RedisAdapter,
+)
 
 from .fake_rules import (
     ShouldNotIncreaseFailureRule,
@@ -26,9 +31,15 @@ def cache(request):
     fake_cache.flushdb()
 
 
-@pytest.fixture
-async def async_cache():
-    fake_cache = AiocacheAdapter(Cache(Cache.MEMORY))
+@pytest.fixture(
+    params=[
+        lambda: AiocacheAdapter(Cache(Cache.MEMORY)),
+        lambda: DjangoAsyncAdapter(LocMemCache(name='test', params={})),
+    ],
+    ids=('AiocacheAdapter', 'DjangoAsyncAdapter',)
+)
+async def async_cache(request):
+    fake_cache = request.param()
     yield fake_cache
     await fake_cache.flushdb()
 


### PR DESCRIPTION
As of Django 4.0 support has been added for [Asynchronous Cache](https://docs.djangoproject.com/en/4.0/topics/cache/#asynchronous-support). With that in this PR I add an adapter for Django where it will be possible to use Django's native asynchronous cache.